### PR TITLE
 fix: remediate CWE-502 Deserialization of Untrusted Data - Checkmarx SAST High

### DIFF
--- a/dataset_utils/dataset_provider.py
+++ b/dataset_utils/dataset_provider.py
@@ -179,7 +179,7 @@ def get_train_loader(data_dir, batch = 4, skip = 1):
 if __name__ == '__main__':
 
 	with open('config/config_kittiSem.yaml') as f:
-		config_dict = yaml.load(f, Loader=yaml.FullLoader)
+		config_dict = yaml.safe_load(f)
 
 	class ConfigClass:
 		def __init__(self, **entries):

--- a/dataset_utils/gnd_data_generator/dataset_generator.py
+++ b/dataset_utils/gnd_data_generator/dataset_generator.py
@@ -30,7 +30,7 @@ plt.ion()
 
 # with open('config/config.yaml') as f:
 with open('config/config_kittiSem.yaml') as f:
-	config_dict = yaml.load(f)
+	config_dict = yaml.safe_load(f)
 
 class ConfigClass:
 	def __init__(self, **entries):

--- a/evaluate_SemanticKITTI.py
+++ b/evaluate_SemanticKITTI.py
@@ -61,7 +61,7 @@ args = parser.parse_args()
 if os.path.isfile(args.config):
     print("using config file:", args.config)
     with open(args.config) as f:
-        config_dict = yaml.load(f, Loader=yaml.FullLoader)
+        config_dict = yaml.safe_load(f)
 
     class ConfigClass:
         def __init__(self, **entries):
@@ -249,7 +249,7 @@ def main():
     if args.resume:
         if os.path.isfile(args.resume):
             print("=> loading checkpoint '{}'".format(args.resume))
-            checkpoint = torch.load(args.resume)
+            checkpoint = torch.load(args.resume, weights_only=True)
             args.start_epoch = checkpoint['epoch']
             lowest_loss = checkpoint['lowest_loss']
             model.load_state_dict(checkpoint['state_dict'])

--- a/infer_rosbag.py
+++ b/infer_rosbag.py
@@ -59,7 +59,7 @@ args = parser.parse_args()
 if os.path.isfile(args.config):
     print("using config file:", args.config)
     with open(args.config) as f:
-        config_dict = yaml.load(f, Loader=yaml.FullLoader)
+        config_dict = yaml.safe_load(f)
 
     class ConfigClass:
         def __init__(self, **entries):
@@ -80,7 +80,7 @@ model = GroundEstimatorNet(cfg).cuda()
 if args.resume:
     if os.path.isfile(args.resume):
         print("=> loading checkpoint '{}'".format(args.resume))
-        checkpoint = torch.load(args.resume)
+        checkpoint = torch.load(args.resume, weights_only=True)
         model.load_state_dict(checkpoint['state_dict'])
         print("=> loaded checkpoint '{}' (epoch {})"
               .format(args.resume, checkpoint['epoch']))

--- a/main.py
+++ b/main.py
@@ -53,7 +53,7 @@ args = parser.parse_args()
 if os.path.isfile(args.config):
     print("using config file:", args.config)
     with open(args.config) as f:
-        config_dict = yaml.load(f, Loader=yaml.FullLoader)
+        config_dict = yaml.safe_load(f)
 
     class ConfigClass:
         def __init__(self, **entries):
@@ -234,7 +234,7 @@ def main():
     if args.resume:
         if os.path.isfile(args.resume):
             print("=> loading checkpoint '{}'".format(args.resume))
-            checkpoint = torch.load(args.resume)
+            checkpoint = torch.load(args.resume, weights_only=True)
             args.start_epoch = checkpoint['epoch']
             lowest_loss = checkpoint['lowest_loss']
             model.load_state_dict(checkpoint['state_dict'])

--- a/misc/dataset_generator.py
+++ b/misc/dataset_generator.py
@@ -30,7 +30,7 @@ plt.ion()
 
 # with open('config/config.yaml') as f:
 with open('config/config_kittiSem.yaml') as f:
-	config_dict = yaml.load(f)
+	config_dict = yaml.safe_load(f)
 
 class ConfigClass:
 	def __init__(self, **entries):

--- a/misc/evaluate.py
+++ b/misc/evaluate.py
@@ -63,7 +63,7 @@ args = parser.parse_args()
 if os.path.isfile(args.config):
     print("using config file:", args.config)
     with open(args.config) as f:
-        config_dict = yaml.load(f, Loader=yaml.FullLoader)
+        config_dict = yaml.safe_load(f)
 
     class ConfigClass:
         def __init__(self, **entries):
@@ -181,7 +181,7 @@ def main():
     if args.resume:
         if os.path.isfile(args.resume):
             print("=> loading checkpoint '{}'".format(args.resume))
-            checkpoint = torch.load(args.resume)
+            checkpoint = torch.load(args.resume, weights_only=True)
             args.start_epoch = checkpoint['epoch']
             lowest_loss = checkpoint['lowest_loss']
             model.load_state_dict(checkpoint['state_dict'])

--- a/model_adapter.py
+++ b/model_adapter.py
@@ -46,12 +46,12 @@ class ModelAdapter(dl.BaseModelAdapter):
                 raise FileNotFoundError(f"Could not find checkpoint file at {self.checkpoint}")
         if os.path.isfile(config):
             with open(config) as f:
-                config_dict = yaml.load(f, Loader=yaml.FullLoader)
+                config_dict = yaml.safe_load(f)
         self.cfg = ConfigClass(**config_dict)
         self.cfg.batch_size = 1
         self.model = GroundEstimatorNet(self.cfg).cuda()
         if os.path.isfile(self.checkpoint):
-            checkpoint = torch.load(self.checkpoint)
+            checkpoint = torch.load(self.checkpoint, weights_only=True)
             self.start_epoch = checkpoint['epoch']
             self.model.load_state_dict(checkpoint['state_dict'])
 


### PR DESCRIPTION
## Summary

Remediate **8 High-severity Checkmarx SAST findings** for **CWE-502: Deserialization of Untrusted Data**.

### Changes

**`torch.load()` — 5 files:**
Added `weights_only=True` to prevent arbitrary code execution via crafted pickle payloads. This restricts deserialization to tensor data only (safe default since PyTorch 2.6).

- `infer_rosbag.py`
- `evaluate_SemanticKITTI.py`
- `main.py`
- `model_adapter.py`
- `misc/evaluate.py`

**`yaml.load()` — 8 files:**
Replaced `yaml.load(f, Loader=yaml.FullLoader)` and `yaml.load(f)` with `yaml.safe_load(f)` to prevent unsafe YAML deserialization. `safe_load` only constructs basic Python types and cannot execute arbitrary code.

- `infer_rosbag.py`
- `evaluate_SemanticKITTI.py`
- `main.py`
- `model_adapter.py`
- `misc/evaluate.py`
- `dataset_utils/dataset_provider.py`
- `dataset_utils/gnd_data_generator/dataset_generator.py`
- `misc/dataset_generator.py`

## Test plan

- [ ] Verify model checkpoint loading still works with `weights_only=True`
- [ ] Verify YAML config files parse correctly with `yaml.safe_load()`
- [ ] Re-run Checkmarx SAST scan to confirm findings are resolved
